### PR TITLE
Fix docker compose config

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,8 @@
+# Air configuration for hot reloading the Go API
+root = "src"
+tmp_dir = "tmp"
+
+[build]
+  cmd = "go build -o ./tmp/content-service ./src"
+  bin = "./tmp/content-service"
+  delay = 1000

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,6 +21,11 @@ This directory contains the Docker configuration for deploying the Autonomous Co
    ./scripts/deploy.sh
    ```
 
+The development compose file mounts `.air.toml` and `Caddyfile.dev` for hot reload:
+```bash
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
 ## Services
 
 The deployment includes the following services:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -9,6 +9,7 @@ services:
       target: builder  # Use builder stage for hot reload
     volumes:
       - ../src:/build/src:ro
+      - ../.air.toml:/build/.air.toml:ro
       - go_mod_cache:/go/pkg/mod
     environment:
       CGO_ENABLED: 0

--- a/docker/docker-compose.simple.yml
+++ b/docker/docker-compose.simple.yml
@@ -106,6 +106,7 @@ services:
       - caddy_config:/config
     environment:
       DOMAIN: ${DOMAIN:-localhost}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@localhost}
       API_URL: http://api:8080
     networks:
       - internal

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -136,6 +136,7 @@ services:
     environment:
       API_URL: http://api:8080
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@trillian.local}
+      DOMAIN: ${DOMAIN:-trillian.local}
     networks:
       - internal
       - external

--- a/docker/services/caddy/Caddyfile
+++ b/docker/services/caddy/Caddyfile
@@ -6,8 +6,8 @@
     https_port 8443
 }
 
-# Main site configuration - only serve on trillian.local domain
-trillian.local:8443 {
+# Main site configuration
+{$DOMAIN:trillian.local}:8443 {
     # Enable compression
     encode gzip zstd
 

--- a/docker/services/caddy/Caddyfile.dev
+++ b/docker/services/caddy/Caddyfile.dev
@@ -1,0 +1,39 @@
+{
+    email {$ADMIN_EMAIL:admin@localhost}
+    http_port 8088
+    https_port 8443
+    auto_https off
+}
+
+{$DOMAIN:localhost}:8088 {
+    encode gzip zstd
+
+    header {
+        -Server
+    }
+
+    handle /api/* {
+        reverse_proxy {$API_URL:http://api:8080}
+    }
+
+    handle {
+        root * /srv/web
+        try_files {path} {path}/ /index.html
+        file_server
+    }
+
+    handle /health {
+        respond "OK" 200
+    }
+
+    handle /api/health {
+        rewrite * /health
+        reverse_proxy {$API_URL:http://api:8080}
+    }
+
+    log {
+        output stdout
+        format console
+        level {$LOG_LEVEL:DEBUG}
+    }
+}


### PR DESCRIPTION
## Summary
- allow Caddy domain to be configured
- mount .air.toml in dev compose
- add admin email to simple compose
- provide Caddyfile.dev for dev deployments
- add Air config

## Testing
- `go test ./...` *(fails: MockEventRepository Save)*

------
https://chatgpt.com/codex/tasks/task_e_684150ba54608330a9169fe4b6d24244